### PR TITLE
Use analogue/orm 5.4 instead of master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.5.0",
         "illuminate/support": "~5.4.0",
-        "analogue/orm": "dev-master"
+        "analogue/orm": "~5.4"
     },
     "require-dev": {
         "laravel/laravel": "~5.4",


### PR DESCRIPTION
I was updating a Laravel project from 5.3 to 5.4 and the composer dependencies caused issues for me. I was unable to update without using orm dev-master.

I think the laravel-auth 5.4 branch and releases should target analogue orm 5.4 instead of master. ThenlLaravel-auth master can target analogue orm master for example.

It would let me avoid pulling from my own fork which I'd appreciate 😄 